### PR TITLE
Avoid strict equality as includes() returns either true or false

### DIFF
--- a/src/Cerberus.js
+++ b/src/Cerberus.js
@@ -25,7 +25,7 @@ class Cerberus {
 
       resources = resources.push({ slug: resource, permission: permission })
 
-      if (resourceNames.includes(resource) === false) resourceNames.push(resource)
+      if (!resourceNames.includes(resource)) resourceNames.push(resource)
 
       return previous
     }, { resources: [], resourceNames: [] })


### PR DESCRIPTION
`includes()` returns only **true** or **false**.
This suggestion is a better practice than using strict comparison.