### PR TITLE
ci(package.json): introduced commitizen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dist
 yarn.lock
 shrinkwrap.yaml
 package-lock.json
+
+# Emacs backup files
+*~

--- a/package.json
+++ b/package.json
@@ -11,11 +11,17 @@
   "devDependencies": {
     "@adonisjs/ace": "^5.0.8",
     "@adonisjs/fold": "^4.0.9",
+    "cz-conventional-changelog": "^3.0.2",
     "eslint": "^6.4.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
This is useful for the standardization of the commits, whether we work alone or in a group.