### PR TITLE
feat(pakcage/japafile/util.spec): set the suit test & wrote first test

### DIFF
--- a/japaFile.js
+++ b/japaFile.js
@@ -1,0 +1,6 @@
+require('ts-node/register')
+
+const { configure } = require('japa')
+configure({
+  files: ['test/**/*.spec.js']
+})

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "1.1.0",
   "description": "Adonis roles and permissions provider",
   "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node japaFile.js"
   },
   "author": "Gustavo Andrade <gustavo@quantumlabs.com.br>",
   "license": "BSD 3-Clause",
   "devDependencies": {
-    "@adonisjs/ace": "^5.0.8",
+    "@adonisjs/ace": "^6.1.6",
     "@adonisjs/fold": "^4.0.9",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^6.4.0",
@@ -17,7 +20,10 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1"
+    "eslint-plugin-standard": "^4.0.1",
+    "japa": "^3.0.1",
+    "ts-node": "^8.4.1",
+    "typescript": "^3.6.3"
   },
   "config": {
     "commitizen": {

--- a/test/util/util.spec.js
+++ b/test/util/util.spec.js
@@ -1,0 +1,6 @@
+const test = require('japa')
+const Util = require('../../util/Util.js')
+
+test('Camelize a string', (assert) => {
+  assert.equal(Util.camelize('Cerberus'), 'cerberus')
+})


### PR DESCRIPTION
Added settings to write our future tests. Implemented one simple test for camelize function just to
show how this works. We use Japa because Virk says it is more suitable for testing AdonisJs. To test
the file, the naive way is to just run: `npm test`.